### PR TITLE
feat: adds build for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/*.link
 .DS_Store
 src/*.tgz
 src/tests/pc_test_comments_dir/*
+bin/*

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ You could use this as a quick starting point for an editor plugin, or tweak the 
 
 ## Building From Source
 
+There are two ways to build from source:
+
+- [Manual approach](#manual-approach): this is the original way for building
+  from source; and
+- [Docker-based approach](#docker-based-approach): you can use this approach to
+  build a Linux binary without needing any additional tools besides
+  [Docker](https://docker.io).
+
+### Manual approach
+
 Once you've cloned this repo you'll need to install [Chicken Scheme](https://www.call-cc.org/) and then run the `install_chicken_eggs.sh` script in the `src` directory. 
 
 If you're hacking on it I recommend running it with `csi`
@@ -198,6 +208,25 @@ $ bash_unit tests/test_client
 
 If it's running `private_comments` will be shut down, and a new instance will be run. The new instance will store its test data separately so you don't have to worry about messing up, or loosing, any existing comments you may have created with private comments.
 
+### Docker-based approach
+
+From the project root directory, run:
+
+```sh
+./linux/make.release.sh
+```
+
+Once the process is completed, this will produce 64-bit Linux binaries in the
+`bin/` directory and an archive with the binaries packaged.  When you run the
+command for the first time, it will take a bit to build the docker container
+used for the build. Subsequent runs will be much faster.
+
+It is possible to build a numbered version by passing the version in the
+environment variable `BUILD_VERSION` as follows:
+
+```sh
+env BUILD_VERSION=1.2.3 ./linux/make.release.sh
+```
 
 ## Contributing
 

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:22.04 as buildenv
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update \
+    && apt-get -y install \
+        libchicken-dev \
+        chicken-bin \
+        build-essential \
+        bash
+
+COPY src/install_chicken_eggs.sh /
+RUN chmod a+x /install_chicken_eggs.sh
+
+RUN /install_chicken_eggs.sh
+
+VOLUME /src

--- a/linux/make.buildenv.sh
+++ b/linux/make.buildenv.sh
@@ -1,6 +1,9 @@
 #! /bin/bash
 # Builds a Docker environment for building private_comments.
 # Run from the project root:
-# 	./build/make.buildenv.sh
+# 	./linux/make.buildenv.sh
 
-docker build -t buildenv -f build/Dockerfile .
+set -x
+set -euo pipefail
+
+docker build -t private_comments_buildenv -f linux/Dockerfile .

--- a/linux/make.buildenv.sh
+++ b/linux/make.buildenv.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+# Builds a Docker environment for building private_comments.
+# Run from the project root:
+# 	./build/make.buildenv.sh
+
+docker build -t buildenv -f build/Dockerfile .

--- a/linux/make.release.sh
+++ b/linux/make.release.sh
@@ -4,17 +4,18 @@
 # Run from the project root.
 
 set -x
+set -euo pipefail
 
 BUILD_VERSION="${BUILD_VERSION:-}"
 
 # Building the build environment, since we don't have a good
 # spot to place the buildenv container.
-./build/make.buildenv.sh
+./linux/make.buildenv.sh
 
 readonly _script_dir="$(pwd)"
 
 docker run --interactive --tty \
 		-u "$(id -u):$(id -g)" \
 		-v "${_script_dir}:/src:rw" \
-		buildenv \
+		private_comments_buildenv \
 		/bin/bash -c "cd /src/src && ./build.sh ${BUILD_VERSION}"

--- a/linux/make.release.sh
+++ b/linux/make.release.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+# Builds a release of private_comments.
+# Run from the project root.
+
+set -x
+
+BUILD_VERSION="${BUILD_VERSION:-}"
+
+# Building the build environment, since we don't have a good
+# spot to place the buildenv container.
+./build/make.buildenv.sh
+
+readonly _script_dir="$(pwd)"
+
+docker run --interactive --tty \
+		-u "$(id -u):$(id -g)" \
+		-v "${_script_dir}:/src:rw" \
+		buildenv \
+		/bin/bash -c "cd /src/src && ./build.sh ${BUILD_VERSION}"

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # required libraries
 
@@ -56,8 +56,9 @@ if [ "$1" != "" ]; then
   perl -pi -e "s/$1/VERSION_NUMBER_HERE/" pc.scm
   perl -pi -e "s/$1/VERSION_NUMBER_HERE/" private_comments.scm
 fi
-ARCHITECTURE=$(arch)
-version_dir="private_comments_"$ARCHITECTURE"_"$VERSION
+readonly OS="$(uname)"
+readonly ARCHITECTURE=$(arch)
+readonly version_dir="../bin/private_comments_${OS}_${ARCHITECTURE}_${VERSION}"
 echo "creating compressed release file..."
 echo "  $version_dir.tgz"
 rm -rf $version_dir
@@ -79,7 +80,7 @@ rm -rf $version_dir
 echo "here's your SHA for homebrew"
 shasum -a 256 $version_dir.tgz
 
-function print_dlibs () {
+function print_dlibs() {
   binary=$1
   echo "DLIBS used by $binary:"
 
@@ -95,8 +96,11 @@ function print_dlibs () {
 }
 
 echo "===================="
-print_dlibs "../bin/private_comments"
-print_dlibs "../bin/pc"
+
+if [[ "${OS}" == "Darwin" ]]; then
+  print_dlibs "../bin/private_comments"
+  print_dlibs "../bin/pc"
+fi
 
 echo "===================="
 echo "Done."

--- a/src/clean.sh
+++ b/src/clean.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+set -x
+
+# Cleans up the build artifacts
+# Run in the top level directory.
+
+rm -vfr *.o *.link
+
+


### PR DESCRIPTION
This change adds some affordances for building private_comments under Linux.  Since I could not guarantee that every builder would have all the necessary tools for building, I wrapped the build process into a docker environment.

This allows an almost trivial build command line:

```
./linux/make.release.sh
```

You need to have docker installed for this to be possible, but it might not be a big concession to make for the ease of building. This still requires root access to run Docker (sigh), but doesn't require you to install a whole new runtime if you are only interested in running the binaries.

I used shell scripts for this purpose to follow the style established in the repository, though I'd have prefered to use some `make` tool.

Issues: #22