### PR TITLE
feat: adds a presubmit test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master  ]
+  schedule:
+    - cron: "43 7 * * 0"
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        runs-on: [ macos-latest ]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v3
+      - if: matrix.runs-on == 'macos-latest'
+        run: "cd ./src && ./build.sh"


### PR DESCRIPTION
Adds a presubmit check that verifies the binaries can be built. It could later be expanded to also run tests if needed. But definitely useful to raise confidence in the submission.